### PR TITLE
implement IP tracker cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Dev workshop athens
+
+### setup deps:
+
+```sh
+nix-shell
+yarn
+```
+
+### build and run
+
+```sh
+yarn start YOUR_NAME
+```
+

--- a/config.json
+++ b/config.json
@@ -1,0 +1,4 @@
+{
+  "ifconfigUri": "https://ifconfig.me/all.json",
+  "geolocationApiUri": "https://api.country.is"
+}

--- a/src/fetchMyIp.ts
+++ b/src/fetchMyIp.ts
@@ -1,0 +1,10 @@
+import fetch from 'node-fetch'
+
+type ResponseType = {
+  ip: string
+}
+
+export const fetchMyIp = (apiUrl: string): Promise<string> =>
+  fetch(apiUrl)
+    .then(res => res.json())
+    .then(bodyAsJson => (bodyAsJson as ResponseType).ip)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from 'node:fs'
+import { fetchMyIp } from './fetchMyIp.js'
+import { getAllData, storeIp } from './ipStore.js'
+import { ipToCountryCode } from './ipToCountryCode.js'
+import { printDataWithCountryCodes } from './printDataWithCountryCodes.js'
+
+const configFile = process.env.CONFIG_FILE || 'config.json'
+const configString = readFileSync(configFile).toString()
+const config = JSON.parse(configString)
+
+const userName = process.argv[3]
+const userIP = await fetchMyIp(config.ifconfigUrl)
+
+storeIp(userName, userIP)
+
+await printDataWithCountryCodes(config)

--- a/src/ipStore.ts
+++ b/src/ipStore.ts
@@ -1,0 +1,28 @@
+import fs from 'node:fs'
+
+const storeFile = process.env.STORE_FILE
+
+export const storeIp = (name: string, ip: string): void => {
+  if (!storeFile) {
+    throw new Error('no storeFile!')
+  }
+
+  const state = JSON.parse(fs.readFileSync(storeFile).toString())
+  const existingNames = Object.keys(state)
+  const caseInsensitiveRegexp = new RegExp(name, 'i')
+
+  const matchingName = existingNames.find(
+    name => !!name.match(caseInsensitiveRegexp)
+  )
+  state[matchingName === undefined ? name : matchingName] = ip
+
+  fs.writeFileSync(storeFile, JSON.stringify(state, null, 2))
+}
+
+export const getAllData = () => {
+  if (!storeFile) {
+    throw new Error('no storeFile!')
+  }
+
+  return JSON.parse(fs.readFileSync(storeFile).toString())
+}

--- a/src/ipToCountryCode.ts
+++ b/src/ipToCountryCode.ts
@@ -1,0 +1,10 @@
+import fetch from 'node-fetch'
+
+type ResponseType = {
+  country: string
+}
+
+export const ipToCountryCode = (apiUrl: string, ip: string): Promise<string> =>
+  fetch(`${apiUrl}/${ip}`)
+    .then(res => res.json())
+    .then(bodyAsJson => (bodyAsJson as ResponseType).country)

--- a/src/printDataWithCountryCodes.ts
+++ b/src/printDataWithCountryCodes.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from 'node:fs'
+import { fetchMyIp } from './fetchMyIp.js'
+import { getAllData } from './ipStore.js'
+import { ipToCountryCode } from './ipToCountryCode.js'
+
+type Config = {
+  geolocationApiUri: string
+}
+
+export const printDataWithCountryCodes = async (
+  { geolocationApiUri }: Config,
+) => {
+  const allData = getAllData()
+
+  for (const ip in allData) {
+    const countryCode = await ipToCountryCode(ip, geolocationApiUri)
+    console.log({ ip, countryCode })
+  }
+}


### PR DESCRIPTION
This cli application takes a user name as a command line argument, and then queries for users current IP and stores it in persistent storage (along other users IPs). Each time the application is ran, given users IP is persisted. Note that users name is case insensitive so if ran with "Adrian", and then with "adrian" use user name, then initial entry will be updated, instead of creating a new one. Once the data for user is added to the store, all IPs from the store are printed to the console along associated country codes.

See README.md for instructions on how to build and run.